### PR TITLE
EzXML / XPath queries

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-LightXML = "9c8b4983-aa76-5018-a973-4c85ecc9e179"
+EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [extras]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,7 +29,6 @@ using TimeZones
     @test pt.altitude == 111.4
 end
 
-
 @testset "read_kml_file" begin
     fname = "sample.kml"
     kmldoc = read_kml_file(fname)
@@ -40,4 +39,3 @@ end
     @test pt.latitude == 46.586349
     @test pt.altitude == 111.4
 end
-


### PR DESCRIPTION
Replace LightXML with EzXML
Use XPath queries
TimeZones 0.10.3 now supports trailing Z