### PR TITLE
TimeZones compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,9 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 EzXML = "8f5d6c58-4d21-5cfd-889c-e3ad7ee6a615"
 TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
+[compat]
+TimeZones = ">= 0.10.3"
+
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 


### PR DESCRIPTION
https://github.com/JuliaTime/TimeZones.jl/pull/227 added trailing Z support (only available since TimeZones 0.10.3)

Required by https://github.com/scls19fr/KMLTracks.jl/commit/78f6065a5271feaac9371b3e008b0f301b1c7168